### PR TITLE
Hide None contributors (e.g. Apps)

### DIFF
--- a/docs/.overrides/main.html
+++ b/docs/.overrides/main.html
@@ -24,15 +24,17 @@
             <span class="contributors-text">Contributors</span>
             <ul class="contributors" data-bi-name="contributors">
                 {%- for user in committers -%}
-                    <li>
-                        <a href="{{ user.repos }}"
-                           title="{{ user.name }}"
-                           data-bi-name="contributorprofile">
-                            <img src="/img/contributor.svg"
-                                 data-src="{{ user.avatar }}?size=32"
-                                 alt="{{ user.name }}"/>
-                        </a>
-                    </li>
+                    {% if user.name %}
+                        <li>
+                            <a href="{{ user.repos }}"
+                               title="{{ user.name }}"
+                               data-bi-name="contributorprofile">
+                                <img src="/img/contributor.svg"
+                                     data-src="{{ user.avatar }}?size=32"
+                                     alt="{{ user.name }}"/>
+                            </a>
+                        </li>
+                    {% endif %}
                 {%- endfor -%}
             </ul>
         </li>


### PR DESCRIPTION
Hides 'None' contributors (e.g. automatic commits from [pre-commit-ci[bot]](https://github.com/apps/pre-commit-ci)) in the page footer.

The only change is [the following](https://github.com/pydev-guide/pydev-guide.github.io/blob/8dff415d99c9f278d3b2b549c832ed7c0240ceb8/docs/.overrides/main.html#L27).