### PR TITLE
Fix CI error with package version

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: ✅ Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # needed for git committers
+          fetch-depth: 0 # needed for git committers
 
       - name: 🐍 Install Python
         uses: actions/setup-python@v4
@@ -26,7 +26,9 @@ jobs:
           python-version: "3.x"
 
       - name: 🔗 Check Links
-        run: npx markdown-link-check docs/**/*.md --progress -q
+        run: |
+          npm install markdown-link-check@"<3.11.1"
+          npx markdown-link-check docs/**/*.md --progress -q
 
       - name: 📚 Build Docs
         run: |


### PR DESCRIPTION
Current build has doesn't pass due to the following error:

```bash
Run npx markdown-link-check docs/**/*.md --progress -q
npm WARN exec The following package was not found and will be installed: markdown-link-check@3.11.1
/home/runner/.npm/_npx/3c3b53b86e3a61f2/node_modules/markdown-link-check/markdown-link-check:99
		input.opts.config = program.opts().config.trim();
		                                         ^

TypeError: Cannot read properties of undefined (reading 'trim')
    at getInputs (/home/runner/.npm/_npx/3c3b53b86e3a61f2/node_modules/markdown-link-check/markdown-link-check:99:44)
    at main (/home/runner/.npm/_npx/3c3b53b86e3a61f2/node_modules/markdown-link-check/markdown-link-check:232:20)

Node.js v18.16.0
Error: Process completed with exit code 1.
```

This is fixed by installing an older version of `markdown-link-check`:

```yaml
- name: 🔗 Check Links
   run: |
       npm install markdown-link-check@"<3.11.1"
       npx markdown-link-check docs/**/*.md --progress -q
```