### PR TITLE
replace TWINE_API_KEY with trusted publishers in quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -354,12 +354,12 @@ ready, you can easily publish your package to the [Python Package Index
         !!!info "One time setup"
             The first time you do this, you'll need to ...
 
-            - [Create a trusted publisher for a new project](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) 
+            - [Create a trusted publisher for a new project](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
             in your PyPI account, if your project is not yet on PyPI.
             - [Create a trusted publisher for an existing project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
             in your PyPI account, if your project is already on PyPI.
 
-                >       *The workflow for automated deployments is `ci.yml` and comes from the 
+                >       *The workflow for automated deployments is `ci.yml` and comes from the
                       `workflows/ci.yml` file*
 
         If you haven't already done so, create an annotated git tag (using `-a`)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -354,14 +354,13 @@ ready, you can easily publish your package to the [Python Package Index
         !!!info "One time setup"
             The first time you do this, you'll need to ...
 
-            1. [Create an API token](https://pypi.org/help/#apitoken) in your
-            PyPI account, if you don't already have one.
-            2. [Create a secret on your github
-            repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
-            named `TWINE_API_KEY`, and add the text of the token you created at PyPI.
+            - [Create a trusted publisher for a new project](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) 
+            in your PyPI account, if your project is not yet on PyPI.
+            - [Create a trusted publisher for an existing project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+            in your PyPI account, if your project is already on PyPI.
 
-                > *The name `TWINE_API_KEY` comes from the variable declared in the
-                `workflows/ci.yml` file*
+                >       *The workflow for automated deployments is `ci.yml` and comes from the 
+                      `workflows/ci.yml` file*
 
         If you haven't already done so, create an annotated git tag (using `-a`)
         on the commit you would like to release and push the commit

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -359,7 +359,7 @@ ready, you can easily publish your package to the [Python Package Index
             - [Create a trusted publisher for an existing project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
             in your PyPI account, if your project is already on PyPI.
 
-                >       *The workflow for automated deployments is `ci.yml` and comes from the
+                > *The workflow for automated deployments is `ci.yml` and comes from the
                       `workflows/ci.yml` file*
 
         If you haven't already done so, create an annotated git tag (using `-a`)


### PR DESCRIPTION
c.f. #21 

Tried to check formatting but had some build issues locally

```txt
Traceback (most recent call last):
  File "/Users/burta2/mambaforge/envs/pydev-guide/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/mkdocs/__main__.py", line 270, in serve_command
    serve.serve(**kwargs)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 86, in serve
    builder(config)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 67, in builder
    build(config, live_server=None if is_clean else server, dirty=is_dirty)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/mkdocs/commands/build.py", line 340, in build
    _build_theme_template(template, env, files, config, nav)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/mkdocs/commands/build.py", line 110, in _build_theme_template
    output = _build_template(template_name, template, files, config, nav)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/mkdocs/commands/build.py", line 89, in _build_template
    output = template.render(context)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/material/templates/404.html", line 4, in top-level template code
    {% extends "main.html" %}
  File "/Users/burta2/programming/pydev-guide.github.io/docs/.overrides/main.html", line 1, in top-level template code
    {% extends "base.html" %}
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/material/templates/base.html", line 154, in top-level template code
    {% block site_nav %}
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/material/templates/base.html", line 162, in block 'site_nav'
    {% include "partials/nav.html" %}
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/material/templates/partials/nav.html", line 4, in top-level template code
    {% import "partials/nav-item.html" as item with context %}
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/jinja2/environment.py", line 1405, in make_module
    return TemplateModule(self, ctx)
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/jinja2/environment.py", line 1535, in __init__
    body_stream = list(template.root_render_func(context))
  File "/Users/burta2/programming/pydev-guide.github.io/docs/.overrides/partials/nav-item.html", line 126, in top-level template code
    {{ render(nav_item, path, level) }}
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/jinja2/runtime.py", line 777, in _invoke
    rv = self._func(*arguments)
  File "/Users/burta2/programming/pydev-guide.github.io/docs/.overrides/partials/nav-item.html", line 5, in template
    {% if nav_item.active %}
  File "/Users/burta2/mambaforge/envs/pydev-guide/lib/python3.10/site-packages/jinja2/environment.py", line 485, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'nav_item' is undefined
```

also deprecations:

```txt
INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

```