### PR TITLE
remove reference to TWINE_API_KEY in deployment.md

### DIFF
--- a/docs/tutorial/github/deployment.md
+++ b/docs/tutorial/github/deployment.md
@@ -45,8 +45,6 @@ jobs:
 
       - name: 🚢 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TWINE_API_KEY }}
 
       - uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
c.f. #21 

after this all references to TWINE_API_KEY are gone from this repo - still need to do the ones in the pyrepo-copier readme