### PR TITLE
docs: pin docs reqs and fix build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Build Docs
 
 on:
   push:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 # Allow this job to clone the repo and create a page deployment
@@ -45,6 +46,7 @@ jobs:
           path: "site/"
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/docs/.overrides/partials/content_next.html
+++ b/docs/.overrides/partials/content_next.html
@@ -1,4 +1,11 @@
-<!-- Link to previous and/or next page -->
+<!-- Link to previous and/or next page 
+
+    This code is borrowed from footer.html, and is enabled by adding
+    "navigation.content_next" to the features list in mkdocs.yml.
+
+    It puts the next and previous page links at the bottom of the content
+    instead of the bottom of the page.
+-->
 {% if "navigation.content_next" in features %}
     {% if page.previous_page or page.next_page %}
         {% if page.meta and page.meta.hide %}

--- a/docs/.overrides/partials/nav-item.html
+++ b/docs/.overrides/partials/nav-item.html
@@ -1,4 +1,8 @@
-<!-- Wrap everything with a macro to reduce file roundtrips (see #2213) -->
+<!-- 
+    This partial is modified to render icons in navigation,
+    but it is no longer necessary after mkdocs-material mkdocs-material 9.2
+    since that version includes the feature by default.
+ -->
 {% macro render(nav_item, path, level) %}
     <!-- Determine class according to state -->
     {% set class = "md-nav__item" %}

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -117,7 +117,7 @@ Run the command: `pip install my_package`
 
 ## Task Lists
 
-* [x] @mentions, #refs, [links](index), **formatting**, and <del>tags</del> supported
+* [x] @mentions, #refs, [links](index.md), **formatting**, and <del>tags</del> supported
 * [x] list syntax required (any unordered or ordered list supported)
 * [x] this is a complete item
 * [ ] this is an incomplete item
@@ -234,8 +234,8 @@ for customizing the icon
 
 ## Buttons
 
-[Subscribe to our newsletter](index){ .md-button .md-button--primary }
+[Subscribe to our newsletter](index.md){ .md-button .md-button--primary }
 
 with icons
 
-[Send :fontawesome-solid-paper-plane:](index){ .md-button }
+[Send :fontawesome-solid-paper-plane:](index.md){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
       - Pre-commit: guides/pre-commit.md
       - Dependency Management: guides/dependencies.md
   - Glossary: glossary.md
-  - "[md demo]": demo.md
+  # - "[md demo]": demo.md
 
 theme:
   name: material

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs
-mkdocs-material
-mkdocs-spellcheck[all]
-mkdocs-git-revision-date-localized-plugin
-mkdocs-git-committers-plugin
-mkdocs-minify-plugin
+mkdocs-material==9.1.18
+mkdocs-material-extensions==1.2
+mkdocs-spellcheck[all]==1.0.2
+mkdocs-git-revision-date-localized-plugin==1.2.4
+mkdocs-git-committers-plugin==0.2.3
+mkdocs-minify-plugin==0.8.0


### PR DESCRIPTION
this PR pins mkdocs-materials to be compatible with our overrides.  Note that some of these internal modifications are now a part of the standard mkdocs material (since v9.2) ... and we should update in another PR to take advantage